### PR TITLE
Only fetch the unique paths

### DIFF
--- a/graphite_influxdb/classes/finder.py
+++ b/graphite_influxdb/classes/finder.py
@@ -207,7 +207,7 @@ class InfluxdbFinder(object):
         :param start_time: Start time of query
         :param end_time: End time of query
         """
-        paths = [n.path for n in nodes]
+        paths = list(set([n.path for n in nodes]))
         series = ', '.join(['"%s"' % path for path in paths])
         interval = calculate_interval(start_time, end_time)
         time_info = start_time, end_time, interval


### PR DESCRIPTION
This was an odd bug to track down...

InfluxDB has a strange behavior when a series is queried multiple times with an aggregate function, it will apply the aggregate function between the series:

`select sum(value) as value from "series1", "series1" where ...` 

Will return a single series, `series1` of course, but all values will be doubled. Requesting `series1` three times will have the values tripled, etc. For other aggregate functions like `mean`, `max`, etc this probably isn't a problem but for `sum` it's way off. 

`graphite-api` doesn't seem to do any dedup on the node list before calling `fetch_multi` so this change only selects the unique paths.